### PR TITLE
Enable Hypervisor Application Support Option for VMWare Fusion Driver

### DIFF
--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -47,6 +47,7 @@ type Driver struct {
 	ConfigDriveISO string
 	ConfigDriveURL string
 	NoShare        bool
+	HypervisorAppsEnabled bool
 }
 
 const (
@@ -108,6 +109,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "vmwarefusion-no-share",
 			Usage:  "Disable the mount of your home directory",
 		},
+		mcnflag.BoolFlag{
+			EnvVar: "FUSION_HYPERVISOR_APPS_ENABLED",
+			Name:   "vmwarefusion-hypervisor-apps-enabled",
+			Usage:  "Enable running Hypervisor Applications by supporting VT-x/EPT inside VM",
+		},
 	}
 }
 
@@ -155,7 +161,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHPassword = flags.String("vmwarefusion-ssh-password")
 	d.SSHPort = 22
 	d.NoShare = flags.Bool("vmwarefusion-no-share")
-
+	d.HypervisorAppsEnabled = flags.Bool("vmwarefusion-hypervisor-apps-enabled")
 	// We support a maximum of 16 cpu to be consistent with Virtual Hardware 10
 	// specs.
 	if d.CPU < 1 {

--- a/drivers/vmwarefusion/vmx_darwin.go
+++ b/drivers/vmwarefusion/vmx_darwin.go
@@ -69,4 +69,7 @@ uuid.action = "create"
 numvcpus = "{{.CPU}}"
 hgfs.mapRootShare = "FALSE"
 hgfs.linkRootShare = "FALSE"
+{{ if .HypervisorAppsEnabled }}
+vhv.enable = "TRUE"
+{{ end }}
 `


### PR DESCRIPTION
## Description
* Added `vmwarefusion-hypervisor-apps-enabled` flag to [fusion_darwin.go](https://github.com/sdunixgeek/machine/blob/master/drivers/vmwarefusion/fusion_darwin.go) as bool indicating that the advanced option should be enabled in the vmx file during provisioning by the driver. Placing the `vhv.enable = "TRUE"` in accordingly. 
* Updated the [vmx_darwin.go](https://github.com/sdunixgeek/machine/blob/master/drivers/vmwarefusion/vmx_darwin.go) template constant to include the appropriate configuration directive to enable when set. 
* Added the kvm_intel module by adding it to a bootlocal.sh during provisioning. Allowing for a restart of the machine to load the module. **NOTE**: This may not be appropriate for all use cases. This can be handled manually when applicable by adding. `modprobe kvm_intel` to `/var/lib/boot2docker/bootlocal.sh` inside of the docker-machine VM then restarting.

### TODO:
 
* Possibly remove the `kvm_intel module` addition to the bootload.sh or allow for this option to be a separate flag that depends on `vmwarefusion-hypervisor-apps-enabled`

## References: 

The case I ran into where this was required was attempting to run the [budtmo/docker-android](https://github.com/budtmo/docker-android/blob/master/README_VMWARE.md) container on MacOS through the vmware-fusion driver.

## Related issue(s)
* [Issue #4741](https://github.com/docker/machine/issues/4741)